### PR TITLE
Replaced advancedBy by swift3 way

### DIFF
--- a/Sources/SwiftHEXColors.swift
+++ b/Sources/SwiftHEXColors.swift
@@ -70,7 +70,7 @@ public extension SWColor {
 
 		// Check for hash and remove the hash
 		if hex.hasPrefix("#") {
-			hex = hex.substringFromIndex(hex.startIndex.advancedBy(1))
+			hex = hex.substring(from : hex.index(hex.startIndex, offsetBy: 1))
 		}
 		
 		guard let hexVal = Int(hex, radix: 16) else {


### PR DESCRIPTION
I made the code compile to the latest Swift3 implementation. The advancedBy() method has been removed in swift3.