### PR TITLE
Resolve "'characters' is deprecated warning"

### DIFF
--- a/Sources/SwiftHEXColors.swift
+++ b/Sources/SwiftHEXColors.swift
@@ -79,7 +79,7 @@ public extension SWColor {
 			return nil
 		}
 		
-		switch hex.characters.count {
+		switch hex.count {
 		case 3:
 			self.init(hex3: hexVal, alpha: alpha)
 		case 6:


### PR DESCRIPTION
Call .count on hex string directly