### PR TITLE
Update Swift-package-manager syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ let package = Package(
     name: "MyPackage",
         dependencies: [
         // Other dependencies
-        .Package(url: "https://github.com/thii/SwiftHEXColors.git", majorVersion: 1)
+	.package(url: "https://github.com/thii/SwiftHEXColors.git", from: "1.3.1")
     ]
 )
 ```


### PR DESCRIPTION
# Summary
The syntax for installing the package via Swift Package Manager has probably changed since when `README.md` was created. This PR is to update the syntax along with the latest release version number* `"1.3.1"`.

\* as of Wednesday, 2 October 2019