### PR TITLE
Added support for 8-digit and 4-digit hex colors

### DIFF
--- a/Sources/SwiftHEXColors/SwiftHEXColors.swift
+++ b/Sources/SwiftHEXColors/SwiftHEXColors.swift
@@ -36,16 +36,6 @@ private extension Int {
 
 /// An extension of UIColor (on iOS) or NSColor (on OSX) providing HEX color handling.
 public extension SWColor {
-    /**
-     Create non-autoreleased color with in the given hex string. Alpha will be set as 1 by default.
-
-     - parameter hexString: The hex string, with or without the hash character.
-     - returns: A color with the given hex string.
-     */
-    convenience init?(hexString: String) {
-        self.init(hexString: hexString, alpha: 1.0)
-    }
-
     private convenience init?(hex3: Int, alpha: Float) {
         self.init(red:   CGFloat( ((hex3 & 0xF00) >> 8).duplicate4bits() ) / 255.0,
                   green: CGFloat( ((hex3 & 0x0F0) >> 4).duplicate4bits() ) / 255.0,
@@ -53,10 +43,24 @@ public extension SWColor {
                   alpha: CGFloat(alpha))
     }
 
+    private convenience init?(hex4: Int, alpha: Float?) {
+        self.init(red:   CGFloat( ((hex4 & 0xF000) >> 12).duplicate4bits() ) / 255.0,
+                  green: CGFloat( ((hex4 & 0x0F00) >> 8).duplicate4bits() ) / 255.0,
+                  blue:  CGFloat( ((hex4 & 0x00F0) >> 4).duplicate4bits() ) / 255.0,
+                  alpha: alpha.map(CGFloat.init) ?? CGFloat( ((hex4 & 0x000F) >> 0).duplicate4bits() ) / 255.0)
+    }
+
     private convenience init?(hex6: Int, alpha: Float) {
         self.init(red:   CGFloat( (hex6 & 0xFF0000) >> 16 ) / 255.0,
                   green: CGFloat( (hex6 & 0x00FF00) >> 8 ) / 255.0,
                   blue:  CGFloat( (hex6 & 0x0000FF) >> 0 ) / 255.0, alpha: CGFloat(alpha))
+    }
+
+    private convenience init?(hex8: Int, alpha: Float?) {
+        self.init(red:   CGFloat( (hex8 & 0xFF000000) >> 24 ) / 255.0,
+                  green: CGFloat( (hex8 & 0x00FF0000) >> 16 ) / 255.0,
+                  blue:  CGFloat( (hex8 & 0x0000FF00) >> 8 ) / 255.0,
+                  alpha: alpha.map(CGFloat.init) ?? CGFloat( (hex8 & 0x000000FF) >> 0 ) / 255.0)
     }
 
     /**
@@ -66,7 +70,7 @@ public extension SWColor {
      - parameter alpha: The alpha value, a floating value between 0 and 1.
      - returns: A color with the given hex string and alpha.
      */
-    convenience init?(hexString: String, alpha: Float) {
+    convenience init?(hexString: String, alpha: Float? = nil) {
         var hex = hexString
 
         // Check for hash and remove the hash
@@ -81,9 +85,13 @@ public extension SWColor {
 
         switch hex.count {
         case 3:
-            self.init(hex3: hexVal, alpha: alpha)
+            self.init(hex3: hexVal, alpha: alpha ?? 1.0)
+        case 4:
+            self.init(hex4: hexVal, alpha: alpha)
         case 6:
-            self.init(hex6: hexVal, alpha: alpha)
+            self.init(hex6: hexVal, alpha: alpha ?? 1.0)
+        case 8:
+            self.init(hex8: hexVal, alpha: alpha)
         default:
             // Note:
             // The swift 1.1 compiler is currently unable to destroy partially initialized classes in all cases,
@@ -95,23 +103,13 @@ public extension SWColor {
     }
 
     /**
-     Create non-autoreleased color with in the given hex value. Alpha will be set as 1 by default.
-
-     - parameter hex: The hex value. For example: 0xff8942 (no quotation).
-     - returns: A color with the given hex value
-     */
-    convenience init?(hex: Int) {
-        self.init(hex: hex, alpha: 1.0)
-    }
-
-    /**
      Create non-autoreleased color with in the given hex value and alpha
 
      - parameter hex: The hex value. For example: 0xff8942 (no quotation).
      - parameter alpha: The alpha value, a floating value between 0 and 1.
      - returns: color with the given hex value and alpha
      */
-    convenience init?(hex: Int, alpha: Float) {
+    convenience init?(hex: Int, alpha: Float = 1.0) {
         if (0x000000 ... 0xFFFFFF) ~= hex {
             self.init(hex6: hex, alpha: alpha)
         } else {

--- a/Tests/SwiftHEXColorsTests/SwiftHEXColorsTests.swift
+++ b/Tests/SwiftHEXColorsTests/SwiftHEXColorsTests.swift
@@ -61,9 +61,28 @@ class SwiftHEXColorsTests: XCTestCase {
         XCTAssertTrue(color! ~= expected)
     }
 
-    func testThat16bitColorIsNil() {
-        let color = SWColor(hexString: "#78A2", alpha: 0.33)
-        XCTAssertNil(color)
+    func testThat16bitColorIsInited() {
+        let color = SWColor(hexString: "#78A2")
+        let expected = SWColor(red: 119 / 255.0, green: 136 / 255.0, blue: 170 / 255.0, alpha: 34 / 255.0)
+        XCTAssertTrue(color! ~= expected)
+    }
+
+    func testThat32bitColorIsInited() {
+        let color = SWColor(hexString: "#81DAB9CC")
+        let expected = SWColor(red: 129.0 / 255.0, green: 218.0 / 255.0, blue: 185.0 / 255.0, alpha: 204 / 255.0)
+        XCTAssertTrue(color! ~= expected)
+    }
+
+    func testThatProvidedAlphaOverrides16bitColorAlpha() {
+        let color = SWColor(hexString: "#78A2", alpha: 0.9)
+        let expected = SWColor(red: 119 / 255.0, green: 136 / 255.0, blue: 170 / 255.0, alpha: 0.9)
+        XCTAssertTrue(color! ~= expected)
+    }
+
+    func testThatProvidedAlphaOverrides32bitColorAlpha() {
+        let color = SWColor(hexString: "#81DAB9CC", alpha: 0.2)
+        let expected = SWColor(red: 129.0 / 255.0, green: 218.0 / 255.0, blue: 185.0 / 255.0, alpha: 0.2)
+        XCTAssertTrue(color! ~= expected)
     }
 
     func testThatNotHexSymbolProducesNil() {


### PR DESCRIPTION
Hi @thii! Long time no see, I hope you're doing well during this crisis.

I'm working on something using your library and I realized that I needed support for 8-digit and 4-digit hex colors, so I went ahead and added that in. I figured I would make a PR in case it's useful to the project. If it's the direction you want to take the project in, feel free to merge and adjust this PR to your liking.

Spec: https://drafts.csswg.org/css-color/#hex-notation
Browser support: https://caniuse.com/#feat=css-rrggbbaa
Examples: https://css-tricks.com/8-digit-hex-codes/

Since the alpha is provided in the hex value, there is no need for the alpha parameter. However, to keep API compatibility, if the user provides the alpha parameter it will take precedence over the hex value. I added the tests to make sure of that.